### PR TITLE
Do connect v0.0.1

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+# pycharm
+.idea/*

--- a/src/boot.py
+++ b/src/boot.py
@@ -10,17 +10,17 @@ def do_connect(ssid="kubernetes lifeline", pwd="workwork"):
         while not wlan.isconnected():
             time.sleep(1)
             wlan.connect(ssid, pwd)
-    print("Done!")
-    from machine import DAC, Pin
-
-    dac = DAC(26)
-    sh = Pin(2, Pin.OUT, Pin.PULL_UP)  # old pin=4
-    sh.value(1)
-    t = DAC.SINE
-    f = 500
-    dac.waveform(f, type=t, scale=0)
-    time.sleep(0.025)
-    dac.stopwave()
     print("network config:", wlan.ifconfig())
 
-do_connect()
+def do_webrepl():
+	import webrepl
+	import machine
+	webrepl.start()
+	pwd = machine.unique_id()
+	# or, start with a specific password
+	webrepl.start(password=pwd)
+
+def no_debug():
+    import esp
+    # this can be run from the REPL as well
+    esp.osdebug(None)

--- a/src/boot.py
+++ b/src/boot.py
@@ -1,0 +1,26 @@
+def do_connect(ssid="kubernetes lifeline", pwd="workwork"):
+    import network
+    import time
+    wlan = network.WLAN(network.STA_IF)
+    wlan.active(True)
+    if not wlan.isconnected():
+        time.sleep(0.1)
+        print("connecting to network... ", end="")
+        wlan.connect(ssid, pwd)
+        while not wlan.isconnected():
+            time.sleep(1)
+            wlan.connect(ssid, pwd)
+    print("Done!")
+    from machine import DAC, Pin
+
+    dac = DAC(26)
+    sh = Pin(2, Pin.OUT, Pin.PULL_UP)  # old pin=4
+    sh.value(1)
+    t = DAC.SINE
+    f = 500
+    dac.waveform(f, type=t, scale=0)
+    time.sleep(0.025)
+    dac.stopwave()
+    print("network config:", wlan.ifconfig())
+
+do_connect()


### PR DESCRIPTION
I lost the original one, which is why there's only this one function in here.

Please, someone! Push up the other two before we merge it in.

Add in a short time.sleep before trying to connect (and trying to connect when not successful again) giving it some time to get properly set up before the check is performed.

Also, for when the rainbow-and-cat combo isn't present as an indicator that it is up and running it now Beeps when the connection to the wifi is made.

Can be moved to the main.py for when you would want the startup-complete-successful/failure to be done when Actually Completely ready.